### PR TITLE
Tesla: Add new Model S HW4 fingerprint

### DIFF
--- a/opendbc/car/tesla/fingerprints.py
+++ b/opendbc/car/tesla/fingerprints.py
@@ -58,6 +58,7 @@ FW_VERSIONS = {
     (Ecu.eps, 0x730, None): [
       b'TeM3_SP_XP002p2_0.0.0 (23),SPP003.6.0',
       b'TeM3_SP_XP002p2_0.0.0 (23),SPR003.6.0',
+      b'TeM3_SP_XP002p2_0.0.0 (36),SPP003.10.0',
     ],
   },
   CAR.TESLA_MODEL_S_HW1: {


### PR DESCRIPTION
This is on the newest Tesla firmware 2025.32 with the Low Power Mode update

Validation
* Dongle ID: 6b7160d3069ea6cb
* Route: 6b7160d3069ea6cb/0000001b--12c04754d4
